### PR TITLE
Update Firestore Rules for Authenticated User Write Access

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,4 +57,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     implementation 'com.google.android.gms:play-services-maps:18.2.0'
     implementation 'com.google.android.libraries.places:places:3.3.0'
+    implementation 'com.google.android.gms:play-services-auth:20.7.0'
 } 

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,6 +1,7 @@
 {
   "project_info": {
     "project_number": "136962826431",
+    "firebase_url": "https://mycoffeeapp-a6df3-default-rtdb.firebaseio.com",
     "project_id": "mycoffeeapp-a6df3",
     "storage_bucket": "mycoffeeapp-a6df3.firebasestorage.app"
   },
@@ -12,7 +13,20 @@
           "package_name": "com.example.mycoffeeapp"
         }
       },
-      "oauth_client": [],
+      "oauth_client": [
+        {
+          "client_id": "136962826431-4u59i844rm0kivdj34cqdsej89383hq8.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.example.mycoffeeapp",
+            "certificate_hash": "79b8ffeb5cdf8306428ea1de5c6cad5126d1400b"
+          }
+        },
+        {
+          "client_id": "136962826431-ig6rdqv83uvecife3ju0nl00hb1sfoeu.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
       "api_key": [
         {
           "current_key": "AIzaSyCkdA9u62WB1-ovsMxvM3wY0itBfSc4g6Y"
@@ -20,7 +34,12 @@
       ],
       "services": {
         "appinvite_service": {
-          "other_platform_oauth_client": []
+          "other_platform_oauth_client": [
+            {
+              "client_id": "136962826431-ig6rdqv83uvecife3ju0nl00hb1sfoeu.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
         }
       }
     }

--- a/app/src/main/java/com/example/mycoffeeapp/Activity/SplashActivity.kt
+++ b/app/src/main/java/com/example/mycoffeeapp/Activity/SplashActivity.kt
@@ -22,17 +22,7 @@ class SplashActivity : AppCompatActivity() {
         setContentView(binding.root)
         auth = FirebaseAuth.getInstance()
 
-        // Kiểm tra trạng thái đăng nhập sau 2 giây
-        Handler(Looper.getMainLooper()).postDelayed({
-            if (auth.currentUser != null) {
-                // Nếu đã đăng nhập, chuyển đến MainActivity
-                startActivity(Intent(this, MainActivity::class.java))
-            } else {
-                // Nếu chưa đăng nhập, chuyển đến LoginActivity
-                startActivity(Intent(this, LoginActivity::class.java))
-            }
-            finish()
-        }, 2000)
+
 
         binding.startBtn.setOnClickListener {
             if (auth.currentUser != null) {

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -118,6 +118,14 @@
         android:textColor="@color/white"
         app:layout_constraintTop_toBottomOf="@id/captchaInputLayout" />
 
+    <com.google.android.gms.common.SignInButton
+        android:id="@+id/googleSignInButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="20dp"
+        app:layout_constraintTop_toBottomOf="@id/loginBtn" />
+
     <TextView
         android:id="@+id/registerBtn"
         android:layout_width="wrap_content"
@@ -127,6 +135,6 @@
         android:textColor="@color/darkBrown"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/loginBtn" />
+        app:layout_constraintTop_toBottomOf="@id/googleSignInButton" />
 
 </androidx.constraintlayout.widget.ConstraintLayout> 


### PR DESCRIPTION
Updates the Firestore security rules to allow only authenticated users to read and write their own data
 Changes
- Replaced temporary open access rule with secure user-based rule
- Ensures only the user with matching `request.auth.uid` can access their own document
